### PR TITLE
[JENKINS-52824] Allow to use GoogleMetadataCredentials

### DIFF
--- a/src/main/resources/com/google/jenkins/plugins/cloudbuild/client/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/cloudbuild/client/Messages.properties
@@ -1,6 +1,7 @@
 ClientFactory.CredentialsIdRequired=credentialsId must be specified
 ClientFactory.FailedToInitializeHTTPTransport=Failed to initialize HTTP transport: {0}
 ClientFactory.FailedToRetrieveCredentials=Could not retrieve credentials: {0}
+ClientFactory.FailedToRetrieveGoogleCredentials=Failed to get required credentials from {0}: {1}
 CloudBuildClient.BuildFailed=Cloud Build failed
 CloudBuildClient.BuildFailedWithStatus=Cloud Build failed. Status: {0}
 CloudBuildClient.BuildId=Build ID: {0}


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-52824

[Google OAuth Plugin](https://wiki.jenkins.io/display/JENKINS/Google+OAuth+Plugin) provides two kinds of credentials:

* [Private Key Credentials](https://wiki.jenkins.io/display/JENKINS/Google+OAuth+Plugin#GoogleOAuthPlugin-PrivateKeyCredentials)
    * http://javadoc.jenkins.io/plugin/google-oauth-plugin/com/google/jenkins/plugins/credentials/oauth/GoogleRobotPrivateKeyCredentials.html
* [Metadata Credentials](https://wiki.jenkins.io/display/JENKINS/Google+OAuth+Plugin#GoogleOAuthPlugin-MetadataCredentials)
    * http://javadoc.jenkins.io/plugin/google-oauth-plugin/com/google/jenkins/plugins/credentials/oauth/GoogleRobotMetadataCredentials.html

Though google-cloudbuild-plugins allows to select metadata credentials in the configuration page, it actually fails with "Could not retrieve credentials". Google-cloudbuild-plugins accepts only `GoogleRobotPrivateKeyCredentials` now.
I want to use metadata credentials.

 Those two credentials have the common ancestor [`GoogleRobotCredentials`](http://javadoc.jenkins.io/plugin/google-oauth-plugin/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.html), and we can easily support both of them by accepting `GoogleRobotCredentials` instead of `GoogleRobotPrivateKeyCredentials`.
