### PR TITLE
[JENKINS-53081] Stream build log

### DIFF
--- a/checkstyleJavaHeader
+++ b/checkstyleJavaHeader
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright 2017 Google Inc\.$
+^ \* Copyright (?:2017|2018) Google Inc\.$
 ^ \*$
 ^ \* Licensed under the Apache License, Version 2\.0 \(the \"License\"\)\; you may not use this file except$
 ^ \* in compliance with the License\. You may obtain a copy of the License at$

--- a/src/main/java/com/google/jenkins/plugins/cloudbuild/CloudBuildInput.java
+++ b/src/main/java/com/google/jenkins/plugins/cloudbuild/CloudBuildInput.java
@@ -55,6 +55,8 @@ public class CloudBuildInput extends AbstractDescribableImpl<CloudBuildInput> im
   @CheckForNull
   private SubstitutionList substitutionList;
 
+  private boolean streamLog;
+
   @DataBoundConstructor
   public CloudBuildInput(@Nonnull String credentialsId, @Nonnull CloudBuildRequest request) {
     this.credentialsId = credentialsId;
@@ -119,6 +121,23 @@ public class CloudBuildInput extends AbstractDescribableImpl<CloudBuildInput> im
   public Map<String, String> getSubstitutionMap(BuildContext context)
       throws IOException, InterruptedException {
     return substitutionList != null ? substitutionList.toMap(context) : Collections.emptyMap();
+  }
+
+  /**
+   * @param streamLog whether to stream log
+   * @since 0.3
+   */
+  @DataBoundSetter
+  public void setStreamLog(boolean streamLog) {
+    this.streamLog = streamLog;
+  }
+
+  /**
+   * @return whether to stream log
+   * @since 0.3
+   */
+  public boolean isStreamLog() {
+    return streamLog;
   }
 
   /** Descriptor for {@link CloudBuildInput}. */

--- a/src/main/java/com/google/jenkins/plugins/cloudbuild/client/LogUtil.java
+++ b/src/main/java/com/google/jenkins/plugins/cloudbuild/client/LogUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 IKEDA Yasuyuki
+ * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/cloudbuild/client/LogUtil.java
+++ b/src/main/java/com/google/jenkins/plugins/cloudbuild/client/LogUtil.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 IKEDA Yasuyuki
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.jenkins.plugins.cloudbuild.client;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nonnull;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+/**
+ * Common classes to pass logs between cloudbuild and cloudstorage
+ *
+ * @since 0.3
+ */
+@Restricted(NoExternalUse.class)
+public class LogUtil {
+    /**
+     * Contains the location of the log
+     */
+    @Restricted(NoExternalUse.class)
+    public static class LogLocation {
+      @Nonnull
+      private final String bucketName;
+      @Nonnull
+      private final String objectName;
+
+      private static final Pattern GSURI_REGEX = Pattern.compile(
+          "^gs://(?<bucket>[^/]+)/(?<object>.*)$",
+          Pattern.CASE_INSENSITIVE
+      );
+
+      /**
+       * @param gsUri gs://bucketname/objectname
+       * @throws IllegalArgumentException Invalid google storage URI
+       */
+      public LogLocation(@Nonnull String gsUri) throws IllegalArgumentException {
+        // We can't use java.net.URI as it rejects invalid hostname
+        // (like ones using undersore).
+        Matcher m = GSURI_REGEX.matcher(gsUri);
+        if (!m.matches()) {
+          throw new IllegalArgumentException(String.format(
+              "Invalid gs URI: %s",
+              gsUri
+          ));
+        }
+        this.bucketName = m.group("bucket");
+        this.objectName = m.group("object");
+      }
+
+      /**
+       * @return bucket name
+       */
+      @Nonnull
+      public String getBucketName() {
+        return bucketName;
+      }
+
+      /**
+       * @return object name
+       */
+      @Nonnull
+      public String getObjectName() {
+        return objectName;
+      }
+    }
+
+    /**
+     * Interface form cloudbuild to trigger cloudstorage
+     * to poll new log outputs.
+     */
+    @Restricted(NoExternalUse.class)
+    public static interface LogPoller {
+     /**
+       * trigger cloud storage client to poll new log outputs
+       * and output them to console.
+       *
+       * @throws IOException errors in communication to cloud storage
+       */
+      void poll() throws IOException;
+    }
+}

--- a/src/main/resources/com/google/jenkins/plugins/cloudbuild/CloudBuildInput/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/cloudbuild/CloudBuildInput/config.jelly
@@ -20,4 +20,7 @@
   </f:optionalBlock>
   <f:dropdownDescriptorSelector title="${%Request}" field="request" />
   <f:property field="substitutionList"/>
+  <f:entry field="streamLog" title="${%Stream build log}">
+    <f:checkbox />
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/com/google/jenkins/plugins/cloudbuild/CloudBuildInput/help-streamLog.html
+++ b/src/main/resources/com/google/jenkins/plugins/cloudbuild/CloudBuildInput/help-streamLog.html
@@ -1,0 +1,4 @@
+<div>
+  Stream the build log of Cloud Build to the console output of Jenkins.
+  Requires the read permission to the log file in Cloud Storage.
+</div>

--- a/src/test/java/com/google/jenkins/plugins/cloudbuild/client/LogUtilTest.java
+++ b/src/test/java/com/google/jenkins/plugins/cloudbuild/client/LogUtilTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.jenkins.plugins.cloudbuild.client;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link LogUtil}
+ */
+public class LogUtilTest {
+  @Test
+  public void testLogLocationBasic() throws Exception {
+    LogUtil.LogLocation location = new LogUtil.LogLocation(
+        "gs://1234567890.cloudbuild-logs.googleusercontent.com/log-xxx.txt"
+    );
+    assertEquals(
+        "1234567890.cloudbuild-logs.googleusercontent.com",
+        location.getBucketName()
+    );
+    assertEquals("log-xxx.txt", location.getObjectName());
+  }
+
+  @Test
+  public void testLogLocationOwnBucket() throws Exception {
+    LogUtil.LogLocation location = new LogUtil.LogLocation(
+        "gs://my-project_cloudbuild-log/log-xxx.txt"
+    );
+    assertEquals("my-project_cloudbuild-log", location.getBucketName());
+    assertEquals("log-xxx.txt", location.getObjectName());
+  }
+
+  @Test
+  public void testLogLocationInDirectory() throws Exception {
+    LogUtil.LogLocation location = new LogUtil.LogLocation(
+        "gs://my-project_cloudbuild/logs/log-xxx.txt"
+    );
+    assertEquals("my-project_cloudbuild", location.getBucketName());
+    assertEquals("logs/log-xxx.txt", location.getObjectName());
+  }
+}

--- a/src/test/resources/com/google/jenkins/plugins/cloudbuild/CloudBuildStepTest/pipelineWithLog.groovy
+++ b/src/test/resources/com/google/jenkins/plugins/cloudbuild/CloudBuildStepTest/pipelineWithLog.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.jenkins.plugins.cloudbuild.CloudBuildStepTest
+
+node {
+    def message = "Hello, World!"
+    googleCloudBuild \
+        credentialsId: 'test-project',
+        source: storage(bucket: 'bucket', object: 'object/path/source.tgz'),
+        request: inline('''
+            steps:
+            - name: ubuntu
+              args: [echo, '$_MESSAGE']
+        '''),
+        substitutions: [_MESSAGE: message],
+        streamLog: true
+}


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-53081

I want to see the build log and its progress in Jenkins console output, just like I can see that with `gloud builds submit`.
This change adds

* "Stream build log" checkbox to "Execute Google Cloud Build" build step.
* "streamLog" parameter to "googleCloudBuild" pipeline step.

This is  performed by polling the log file on Cloud Storage. It retrieves only the appended part using "Range:" HTTP header.

Screenshots:

* "Stream build log" checkbox to "Execute Google Cloud Build" build step.
    
    ![streambuildlog](https://user-images.githubusercontent.com/3115961/44295219-e2b94700-a2df-11e8-9312-dd98e0e0ee90.png)

* Console output

    ![screenshot_2018-08-18-test- 51-console- jenkins](https://user-images.githubusercontent.com/3115961/44295224-ee0c7280-a2df-11e8-8bb1-3d02b5eaea7b.png)
