### PR TITLE
[FIXED JENKINS-53107] Support HTTP proxy

### DIFF
--- a/checkstyleJavaHeader
+++ b/checkstyleJavaHeader
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright 2017 Google Inc\.$
+^ \* Copyright (?:2017|2018) Google Inc\.$
 ^ \*$
 ^ \* Licensed under the Apache License, Version 2\.0 \(the \"License\"\)\; you may not use this file except$
 ^ \* in compliance with the License\. You may obtain a copy of the License at$

--- a/src/main/java/com/google/jenkins/plugins/cloudbuild/CloudBuildBuilder.java
+++ b/src/main/java/com/google/jenkins/plugins/cloudbuild/CloudBuildBuilder.java
@@ -50,11 +50,13 @@ public class CloudBuildBuilder extends Builder {
   @Override
   public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
       throws IOException, InterruptedException {
-    BuildContext context = new FreeStyleBuildContext(build, listener);
+    // allow specifying proxy like ${https_proxy}
+    String proxy = build.getEnvironment(listener).expand(input.getProxy());
+    BuildContext context = new FreeStyleBuildContext(build, listener, proxy);
     ClientFactory clients = new ClientFactory(build, listener, input.getCredentialsId());
     String finalRequest = input.getRequest().expand(context);
     Source buildSource = input.getSourceOrDefault().prepare(context, clients);
-    CloudBuildClient cloudBuild = clients.cloudBuild();
+    CloudBuildClient cloudBuild = clients.cloudBuild(proxy);
     String buildId = cloudBuild.sendBuildRequest(
         finalRequest, buildSource, input.getSubstitutionMap(context));
     cloudBuild.waitForSuccess(buildId);

--- a/src/main/java/com/google/jenkins/plugins/cloudbuild/CloudBuildInput.java
+++ b/src/main/java/com/google/jenkins/plugins/cloudbuild/CloudBuildInput.java
@@ -55,6 +55,9 @@ public class CloudBuildInput extends AbstractDescribableImpl<CloudBuildInput> im
   @CheckForNull
   private SubstitutionList substitutionList;
 
+  @CheckForNull
+  private String proxy;
+
   @DataBoundConstructor
   public CloudBuildInput(@Nonnull String credentialsId, @Nonnull CloudBuildRequest request) {
     this.credentialsId = credentialsId;
@@ -119,6 +122,23 @@ public class CloudBuildInput extends AbstractDescribableImpl<CloudBuildInput> im
   public Map<String, String> getSubstitutionMap(BuildContext context)
       throws IOException, InterruptedException {
     return substitutionList != null ? substitutionList.toMap(context) : Collections.emptyMap();
+  }
+
+  /**
+   * @param proxy proxy to use to connect Google Cloud services.
+   * @since 0.3
+   */
+  @DataBoundSetter
+  public void setProxy(@CheckForNull String proxy) {
+    this.proxy = proxy;
+  }
+
+  /**
+   * @return proxy to use to connect Google Cloud services.
+   */
+  @CheckForNull
+  public String getProxy() {
+    return proxy;
   }
 
   /** Descriptor for {@link CloudBuildInput}. */

--- a/src/main/java/com/google/jenkins/plugins/cloudbuild/CloudBuildStepExecution.java
+++ b/src/main/java/com/google/jenkins/plugins/cloudbuild/CloudBuildStepExecution.java
@@ -77,7 +77,7 @@ public final class CloudBuildStepExecution extends StepExecution {
   private void startPolling() {
     task = getExecutorService().submit(() -> {
       try {
-        getClients().cloudBuild().waitForSuccess(buildId);
+        getClients().cloudBuild(input.getProxy()).waitForSuccess(buildId);
         getContext().onSuccess(null);
       } catch (Exception e) {
         getContext().onFailure(e);
@@ -87,8 +87,8 @@ public final class CloudBuildStepExecution extends StepExecution {
 
   @Override
   public boolean start() throws Exception {
-    BuildContext context = new PipelineBuildContext(getContext());
-    buildId = getClients().cloudBuild().sendBuildRequest(
+    BuildContext context = new PipelineBuildContext(getContext(), input.getProxy());
+    buildId = getClients().cloudBuild(input.getProxy()).sendBuildRequest(
         input.getRequest().expand(context),
         input.getSourceOrDefault().prepare(context, getClients()),
         input.getSubstitutionMap(context));

--- a/src/main/java/com/google/jenkins/plugins/cloudbuild/client/ClientFactory.java
+++ b/src/main/java/com/google/jenkins/plugins/cloudbuild/client/ClientFactory.java
@@ -14,12 +14,25 @@
 package com.google.jenkins.plugins.cloudbuild.client;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.google.api.client.googleapis.GoogleUtils;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.cloudbuild.v1.CloudBuild;
@@ -33,8 +46,12 @@ import hudson.model.TaskListener;
 /** Creates clients for communicating with Google APIs. */
 public class ClientFactory {
   public static final String APPLICATION_NAME = "cloud-build-plugin";
+  private static final Logger LOG = Logger.getLogger(ClientFactory.class.getName());
 
   private static HttpTransport DEFAULT_TRANSPORT;
+  @Nonnull
+  private static Map<String, HttpTransport> proxyTransportCache
+      = new HashMap<>();
 
   private final Run<?, ?> run;
   private final TaskListener listener;
@@ -75,12 +92,54 @@ public class ClientFactory {
     }
   }
 
-  private static synchronized HttpTransport getDefaultTransport()
+  /*package*/ static synchronized HttpTransport getDefaultTransport()
       throws GeneralSecurityException, IOException {
     if (DEFAULT_TRANSPORT == null) {
       DEFAULT_TRANSPORT = GoogleNetHttpTransport.newTrustedTransport();
     }
     return DEFAULT_TRANSPORT;
+  }
+
+  /*package*/ static synchronized HttpTransport getTransportWithProxy(@CheckForNull String proxy)
+      throws GeneralSecurityException, IOException {
+    if (proxy == null || proxy.isEmpty()) {
+      return getDefaultTransport();
+    }
+    if (proxyTransportCache.containsKey(proxy)) {
+      return proxyTransportCache.get(proxy);
+    }
+
+    URI proxyUri;
+    try {
+      proxyUri = new URI(proxy);
+    } catch (URISyntaxException e) {
+      LOG.log(
+          Level.WARNING,
+          String.format("Invalid proxy. ignored: %s", proxy),
+          e
+      );
+      return getDefaultTransport();
+    }
+    if (
+        proxyUri.getScheme() == null
+        || !"http".equals(proxyUri.getScheme().toLowerCase())
+        || proxyUri.getHost() == null
+    ) {
+      LOG.log(
+          Level.WARNING,
+          "Invalid proxy. ignored: {0}",
+          proxy
+        );
+        return getDefaultTransport();
+    }
+    HttpTransport transport = new NetHttpTransport.Builder()
+        .trustCertificates(GoogleUtils.getCertificateTrustStore())
+        .setProxy(new Proxy(
+            Proxy.Type.HTTP,
+            new InetSocketAddress(proxyUri.getHost(), proxyUri.getPort())))
+        .build();
+    proxyTransportCache.put(proxy, transport);
+    return transport;
   }
 
   public static synchronized void setDefaultTransport(HttpTransport transport) {
@@ -96,11 +155,60 @@ public class ClientFactory {
         credentials.getProjectId(), run, listener);
   }
 
+  /**
+   * @param proxy proxy to use in "http://..." format. can be null or empty.
+   * @return Client for Cloud Build with the proxy.
+   * @throws IOException error in certificate store handling
+   * @since 0.3
+   */
+  public CloudBuildClient cloudBuild(@CheckForNull String proxy)
+      throws IOException {
+    try {
+      return new CloudBuildClient(
+          new CloudBuild.Builder(
+              getTransportWithProxy(proxy),
+              jsonFactory,
+              gcred
+          )
+              .setRootUrl("https://cloudbuild.googleapis.com/")
+              .setApplicationName(APPLICATION_NAME)
+              .build(),
+          credentials.getProjectId(), run, listener);
+    } catch (GeneralSecurityException e) {
+      throw new AbortException(
+          Messages.ClientFactory_FailedToInitializeHTTPTransport(e.getMessage()));
+    }
+  }
+
   public CloudStorageClient storage() {
     return new CloudStorageClient(
         new Storage.Builder(transport, jsonFactory, gcred)
             .setApplicationName(APPLICATION_NAME)
             .build(),
         credentials.getProjectId(), listener);
+  }
+
+  /**
+   * @param proxy proxy to use in "http://..." format. can be null or empty.
+   * @return Client for Cloud Storage with the proxy.
+   * @throws IOException error in certificate store handling
+   * @since 0.3
+   */
+  public CloudStorageClient storage(@CheckForNull String proxy)
+      throws IOException {
+    try {
+      return new CloudStorageClient(
+          new Storage.Builder(
+              getTransportWithProxy(proxy),
+              jsonFactory,
+              gcred
+          )
+              .setApplicationName(APPLICATION_NAME)
+              .build(),
+          credentials.getProjectId(), listener);
+    } catch (GeneralSecurityException e) {
+      throw new AbortException(
+          Messages.ClientFactory_FailedToInitializeHTTPTransport(e.getMessage()));
+    }
   }
 }

--- a/src/main/java/com/google/jenkins/plugins/cloudbuild/context/BuildContext.java
+++ b/src/main/java/com/google/jenkins/plugins/cloudbuild/context/BuildContext.java
@@ -41,4 +41,11 @@ public interface BuildContext {
   FilePath getWorkspace() throws IOException, InterruptedException;
 
   TaskListener getListener() throws IOException, InterruptedException;
+
+  /**
+   * @return proxy to use for Cloud Platform services.
+   * @since 0.3
+   */
+  @CheckForNull
+  String getProxy();
 }

--- a/src/main/java/com/google/jenkins/plugins/cloudbuild/context/FreeStyleBuildContext.java
+++ b/src/main/java/com/google/jenkins/plugins/cloudbuild/context/FreeStyleBuildContext.java
@@ -15,6 +15,8 @@ package com.google.jenkins.plugins.cloudbuild.context;
 
 import java.io.IOException;
 
+import javax.annotation.CheckForNull;
+
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
@@ -22,12 +24,20 @@ import hudson.model.TaskListener;
 
 /** The context of the currently running Jenkins build. */
 public class FreeStyleBuildContext implements BuildContext {
-  private final AbstractBuild build;
+  private final AbstractBuild<?, ?> build;
   private final BuildListener listener;
+  @CheckForNull
+  private final String proxy;
 
   public FreeStyleBuildContext(AbstractBuild build, BuildListener listener) {
+      this(build, listener, null);
+    }
+
+  public FreeStyleBuildContext(AbstractBuild<?, ?> build,
+      BuildListener listener, @CheckForNull String proxy) {
     this.build = build;
     this.listener = listener;
+    this.proxy = proxy;
   }
 
   @Override
@@ -43,5 +53,11 @@ public class FreeStyleBuildContext implements BuildContext {
   @Override
   public TaskListener getListener() {
     return listener;
+  }
+
+  @Override
+  @CheckForNull
+  public String getProxy() {
+    return proxy;
   }
 }

--- a/src/main/java/com/google/jenkins/plugins/cloudbuild/context/PipelineBuildContext.java
+++ b/src/main/java/com/google/jenkins/plugins/cloudbuild/context/PipelineBuildContext.java
@@ -15,6 +15,8 @@ package com.google.jenkins.plugins.cloudbuild.context;
 
 import java.io.IOException;
 
+import javax.annotation.CheckForNull;
+
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
 import hudson.FilePath;
@@ -23,9 +25,21 @@ import hudson.model.TaskListener;
 /** The context of the currently running Jenkins build. */
 public class PipelineBuildContext implements BuildContext {
   private final StepContext stepContext;
+  @CheckForNull
+  private final String proxy;
 
   public PipelineBuildContext(StepContext stepContext) {
+    this(stepContext, null);
+  }
+
+  /**
+   * @param stepContext context of pipeline step.
+   * @param proxy proxy to use for Cloud Platform services.
+   * @since 0.3
+   */
+  public PipelineBuildContext(StepContext stepContext, @CheckForNull String proxy) {
     this.stepContext = stepContext;
+    this.proxy = proxy;
   }
 
   @Override
@@ -41,5 +55,11 @@ public class PipelineBuildContext implements BuildContext {
   @Override
   public TaskListener getListener() throws IOException, InterruptedException {
     return stepContext.get(TaskListener.class);
+  }
+
+  @Override
+  @CheckForNull
+  public String getProxy() {
+    return proxy;
   }
 }

--- a/src/main/java/com/google/jenkins/plugins/cloudbuild/source/LocalCloudBuildSource.java
+++ b/src/main/java/com/google/jenkins/plugins/cloudbuild/source/LocalCloudBuildSource.java
@@ -102,7 +102,7 @@ public class LocalCloudBuildSource extends CloudBuildSource implements Serializa
       throw new AbortException(Messages.LocalCloudBuildSource_SourcePathDoesNotExist());
     }
 
-    CloudStorageClient storage = clients.storage();
+    CloudStorageClient storage = clients.storage(context.getProxy());
     String bucket = storage.createTempBucket();
     String objectBaseName = String.format("source/%d-%s", System.currentTimeMillis(),
         UUID.randomUUID().toString());

--- a/src/main/resources/com/google/jenkins/plugins/cloudbuild/CloudBuildInput/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/cloudbuild/CloudBuildInput/config.jelly
@@ -20,4 +20,9 @@
   </f:optionalBlock>
   <f:dropdownDescriptorSelector title="${%Request}" field="request" />
   <f:property field="substitutionList"/>
+  <f:advanced>
+    <f:entry field="proxy" title="${%HTTP Proxy}">
+      <f:textbox />
+    </f:entry>
+  </f:advanced>
 </j:jelly>

--- a/src/main/resources/com/google/jenkins/plugins/cloudbuild/CloudBuildInput/help-proxy.html
+++ b/src/main/resources/com/google/jenkins/plugins/cloudbuild/CloudBuildInput/help-proxy.html
@@ -1,0 +1,5 @@
+<div>
+  Specify HTTP proxy to use to connect Cloud Platform services
+  in the form of "http://host:port/" like http_proxy environment variable.
+  You can use variable expressions like ${https_proxy}.
+</div>

--- a/src/test/java/com/google/jenkins/plugins/cloudbuild/client/ClientFactoryTest.java
+++ b/src/test/java/com/google/jenkins/plugins/cloudbuild/client/ClientFactoryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.jenkins.plugins.cloudbuild.client;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link ClientFactory}
+ */
+public class ClientFactoryTest {
+  @Test
+  public void getTransportWithProxy() throws Exception {
+    assertNotSame(
+        ClientFactory.getDefaultTransport(),
+        ClientFactory.getTransportWithProxy("http://localhost:3128/")
+    );
+  }
+
+  @Test
+  public void getTransportWithProxyCached() throws Exception {
+    assertSame(
+        ClientFactory.getTransportWithProxy("http://localhost:3128/"),
+        ClientFactory.getTransportWithProxy("http://localhost:3128/")
+    );
+  }
+
+  @Test
+  public void getTransportWithProxyNull() throws Exception {
+    assertSame(
+        ClientFactory.getDefaultTransport(),
+        ClientFactory.getTransportWithProxy(null)
+    );
+  }
+
+  @Test
+  public void getTransportWithProxyEmpty() throws Exception {
+    assertSame(
+        ClientFactory.getDefaultTransport(),
+        ClientFactory.getTransportWithProxy(null)
+    );
+  }
+
+  @Test
+  public void getTransportWithProxyInvalid() throws Exception {
+    assertSame(
+        ClientFactory.getDefaultTransport(),
+        ClientFactory.getTransportWithProxy("badproxyformat")
+    );
+  }
+
+  @Test
+  public void getTransportWithProxyInvlidHost() throws Exception {
+    assertSame(
+        ClientFactory.getDefaultTransport(),
+        ClientFactory.getTransportWithProxy(
+            "http://underscore_is_not_valid_hostname:8080/"
+        )
+    );
+  }
+}

--- a/src/test/java/com/google/jenkins/plugins/cloudbuild/source/LocalCloudBuildSourceTest.java
+++ b/src/test/java/com/google/jenkins/plugins/cloudbuild/source/LocalCloudBuildSourceTest.java
@@ -60,7 +60,7 @@ public class LocalCloudBuildSourceTest {
   @Before
   public void setUp() throws IOException {
     MockitoAnnotations.initMocks(this);
-    when(clients.storage()).thenReturn(storage);
+    when(clients.storage(any())).thenReturn(storage);
   }
 
   @Test


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-53107

My environment requires HTTP proxy to connect Internet services.
Unfortunately, google-cloudbuild-plugin doesn't support HTTP proxies such as "http.proxyHost" system properties.
(Anyway, it looks difficult to support both "http.proxyHosts" and "http.nonProxyHosts")

This change allow users to specify HTTP proxy:

* Freestyle:

    ![proxy](https://user-images.githubusercontent.com/3115961/44305707-5c713380-a3b9-11e8-9779-e7a0bceaa594.png)

* pipeline:
    ```
    googleCloudBuild(
        credentialsId: 'my-project',
        source: local('.'),
        request: file('cloudbuild.yaml'),
        proxy: env.https_proxy,
    );
    ```

As in above, I expect to use this feature to use appropriate proxies for each slave nodes with environment variables.
